### PR TITLE
config(renovate): disable angular major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,27 @@
 {
-  "extends": [
-    "config:js-lib"
-  ],
+  "extends": ["config:js-lib"],
   "automerge": false,
   "patch": {
     "automerge": true
   },
   "devDependencies": {
     "automerge": true
-  }
+  },
+  "packageRules": [
+    {
+      "packagePatterns": [
+        "^@angular/",
+        "^zone.js$",
+        "^@angular-devkit/",
+        "^jasmine",
+        "karma",
+        "ng-packgr",
+        "protractor",
+        "tslint",
+        "typescript"
+      ],
+      "updateTypes": ["major"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
ssia. Angular majos updates are handled by `ng update` so upgrading these with renovate will break things. 

Hopefully this config works 😅 

EDIT: seems like it: https://github.com/renovatebot/config-help/issues/260#issuecomment-497928046