### PR TITLE
config(semantic-release): run on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ deploy:
   script:
     - npm run publish-semantic-release
   on:
-    branch: next
+    all_branches: true
 
 branches:
   only:


### PR DESCRIPTION
This PR enables semantic-release to run on the main branch, in prep for public release 🚀 