### PR TITLE
config: auto-release dependency updates (excluding devDeps)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,11 @@
             {
               "type": "docs",
               "release": "patch"
+            },
+            {
+              "type": "chore",
+              "scope": "deps",
+              "release": "patch"
             }
           ]
         }

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,14 @@
       ],
       "updateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "depTypeList": ["dependencies", "peerDependencies"],
+      "semanticCommitScope": "deps"
+    },
+    {
+      "depTypeList": ["devDependencies"],
+      "semanticCommitScope": "dev-deps"
     }
   ]
 }


### PR DESCRIPTION
This *should* work, I might come back on Monday and see if I can refine this or anything. I don't really think there's a way to test it without merging it. Maybe I can just merge the renovate changes first and then test the semantic changes locally.