### PR TITLE
docs: update library description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![imgix logo](https://assets.imgix.net/sdk-imgix-logo.svg)
 
-`@imgix/angular` is a client library for generating URLs with [imgix](https://www.imgix.com/).
+`@imgix/angular` provides custom components for integrating [imgix](https://www.imgix.com/) into Angular applications.
 
 [![npm version](https://img.shields.io/npm/v/@imgix/angular.svg)](https://www.npmjs.com/package/@imgix/angular)
 [![Build Status](https://travis-ci.org/imgix/angular.svg?branch=main)](https://travis-ci.org/imgix/angular)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "imgix-angular-workspace",
   "version": "0.0.0",
-  "description": "A library that provides custom components for integrating imgix into Angular applications",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "imgix-angular-workspace",
   "version": "0.0.0",
+  "description": "A library that provides custom components for integrating imgix into Angular applications",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/imgix-angular/package.json
+++ b/projects/imgix-angular/package.json
@@ -1,6 +1,32 @@
 {
   "name": "@imgix/angular",
   "version": "0.0.0-semantically-released",
+  "description": "A library that provides custom components for integrating imgix into Angular applications",
+  "author": "Frederick Fogerty <frederick.fogerty@gmail.com> (https://github.com/frederickfogerty)",
+  "contributors": [
+    "Frederick Fogerty <frederick.fogerty@gmail.com> (https://github.com/frederickfogerty)",
+    "Sherwin Heydarbeygi <sherwin@imgix.com> (https://github.com/sherwinski)"
+  ],
+  "keywords": [
+    "angular",
+    "imgix",
+    "component",
+    "ng-imgix",
+    "imgix-ng",
+    "responsive",
+    "srcset",
+    "img",
+    "picture",
+    "dynamic"
+  ],
+  "homepage": "https://github.com/imgix/angular#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/imgix/angular.git"
+  },
+  "bugs": {
+    "url": "https://github.com/imgix/angular/issues"
+  },
   "license": "BSD-2-Clause",
   "peerDependencies": {},
   "private": false,


### PR DESCRIPTION
This PR adds a `description` field to the root `package.json` to avoid an empty/incorrect one from being displayed on the npm registry. See screenshot:

<img width="427" alt="image" src="https://user-images.githubusercontent.com/15919091/97062090-396cdc00-154e-11eb-9cf0-bbdedc065bfd.png">

This PR also updates the description to offer more detail about this library's features. If we're good with this description, I'll also update it in this repo's "About" section. 

<img width="296" alt="image" src="https://user-images.githubusercontent.com/15919091/97062209-b730e780-154e-11eb-8229-69eb592f6a36.png">
