### PR TITLE
ci: update supported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: trusty
 
 language: node_js
 node_js:
+  - lts/*
   - stable
 
 addons:

--- a/projects/imgix-angular/package.json
+++ b/projects/imgix-angular/package.json
@@ -28,7 +28,6 @@
     "url": "https://github.com/imgix/angular/issues"
   },
   "license": "BSD-2-Clause",
-  "peerDependencies": {},
   "private": false,
   "publishConfig": {
     "access": "public"
@@ -38,5 +37,10 @@
     "imgix-url-params": "^11.9.1",
     "tslib": "^2.0.2",
     "urijs": "1.19.3"
+  },
+  "peerDependencies": {
+    "@angular/common": "8.x || 9.x || 10.x || 11.x",
+    "@angular/core": "8.x || 9.x || 10.x || 11.x",
+    "@angular/platform-browser": "8.x || 9.x || 10.x || 11.x"
   }
 }


### PR DESCRIPTION
Adds [currently supported](https://nodejs.org/en/about/releases/) and all LTS node versions to CI.