### PR TITLE
config(renovate): disable typescript minor version updates to ensure compatibility with angular

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ts-node": "9.1.1",
     "tslib": "2.1.0",
     "tslint": "6.1.3",
-    "typescript": "4.1.3",
+    "typescript": "^4.0.2",
     "zone.js": "0.11.3"
   },
   "release": {

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,13 @@
       ],
       "updateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "packagePatterns": [
+        "typescript"
+      ],
+      "updateTypes": ["major", "minor"],
+      "enabled": false
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12456,7 +12456,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.0.2:
+typescript@4.0.2, typescript@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
   integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
@@ -12465,11 +12465,6 @@ typescript@4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
   integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
-
-typescript@4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 ua-parser-js@0.7.22:
   version "0.7.22"


### PR DESCRIPTION
This should fix the semantic release step on `main`.

I tested the failing build step locally and it worked:

![image](https://user-images.githubusercontent.com/615334/103755954-f54a8d00-500e-11eb-8a55-63276a4ae3a3.png)
