### PR TITLE
config: update auto-release workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,3 @@ deploy:
     - npm run publish-semantic-release
   on:
     all_branches: true
-
-branches:
-  only:
-    - main
-    - next
-    - /^v.*$/

--- a/package.json
+++ b/package.json
@@ -84,11 +84,63 @@
             {
               "type": "docs",
               "release": "patch"
+            },
+            {
+              "type": "deps",
+              "scope": "deps",
+              "release": "patch"
             }
           ]
         }
       ],
-      "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "conventionalcommits",
+          "writerOpts": {
+            "types": [
+              {
+                "type": "feat",
+                "section": "Features"
+              },
+              {
+                "type": "fix",
+                "section": "Bug Fixes"
+              },
+              {
+                "type": "docs",
+                "section": "Documentation",
+                "hidden": false
+              },
+              {
+                "type": "deps",
+                "section": "Dependency Updates",
+                "hidden": false
+              },
+              {
+                "type": "chore",
+                "hidden": true
+              },
+              {
+                "type": "style",
+                "hidden": true
+              },
+              {
+                "type": "refactor",
+                "hidden": true
+              },
+              {
+                "type": "perf",
+                "hidden": true
+              },
+              {
+                "type": "test",
+                "hidden": true
+              }
+            ]
+          }
+        }
+      ],
       [
         "@semantic-release/exec",
         {

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,5 @@
 {
-  "extends": ["config:js-lib"],
-  "automerge": false,
-  "patch": {
-    "automerge": true
-  },
-  "devDependencies": {
-    "automerge": true
-  },
+  "extends": ["github>imgix/renovate-config"],
   "packageRules": [
     {
       "packagePatterns": [
@@ -24,9 +17,7 @@
       "enabled": false
     },
     {
-      "packagePatterns": [
-        "typescript"
-      ],
+      "packagePatterns": ["typescript"],
       "updateTypes": ["major", "minor"],
       "enabled": false
     }


### PR DESCRIPTION
This PR updates the auto-release/dependency workflow to adopt imgix's shared Renovate config and changes needed due this adoption. Specifically:

Renovate's config is based on the shared imgix configuration
Travis no longer builds PRs, and instead builds all branches
Semantic release will release and generate release notes for dependency (excl. dev dependency) updates, as well as doc PRs (previously it didn't generate release notes for these)