### PR TITLE
config(semantic-release): fix replace-plugin to match on version definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
       [
         "@semantic-release/exec",
         {
-          "prepareCmd": "cp README.md projects/imgix-angular/ &&  ./node_modules/.bin/ng build imgix-angular"
+          "prepareCmd": "cp README.md projects/imgix-angular/ && ./node_modules/.bin/ng build imgix-angular"
         }
       ],
       [
@@ -156,8 +156,8 @@
               "files": [
                 "projects/imgix-angular/src/common/constants.ts"
               ],
-              "from": "IMGIX_NG_VERSION: string = '.*'",
-              "to": "IMGIX_NG_VERSION: string = '${nextRelease.version}'",
+              "from": "export const IMGIX_NG_VERSION: string = '.*'",
+              "to": "export const IMGIX_NG_VERSION: string = '${nextRelease.version}'",
               "results": [
                 {
                   "file": "projects/imgix-angular/src/common/constants.ts",


### PR DESCRIPTION
I noticed that the constant used to set the `ixlib` version has not been in sync with the project's actual version for some time. I am guessing it is due to an issue with the semantic-release plugin config that causes it to skip over the constant during release.
It is difficult to know if this fix actually works as this plugin gets skipped over when running semantic-release in dryRun mode. Open to ideas on how to test this, e.g. test release on `next` as opposed to `main`. 

See example of `ixlib` value after installing imgix/angular@1.1.6:

```
<img
  iximg=""
  path="examples/pione.jpg"
  src="https://assets.imgix.net/examples/pione.jpg?ixlib=ng-1.0.0-rc.1&amp;auto=format%2Ccompress"
  srcset="
    https://assets.imgix.net/examples/pione.jpg?ixlib=ng-1.0.0-rc.1&amp;auto=format%2Ccompress&amp;w=100 100w,
    https://assets.imgix.net/examples/pione.jpg?ixlib=ng-1.0.0-rc.1&amp;auto=format%2Ccompress&amp;w=116 116w,
    ...
```

Expected:
The `ixlib` version should match whatever the current package version is.