### PR TITLE
fix(ix-img): set directive attributes after view init

### DIFF
--- a/projects/imgix-angular/src/lib/ix-img.component.ts
+++ b/projects/imgix-angular/src/lib/ix-img.component.ts
@@ -1,5 +1,5 @@
 import {
-  AfterViewChecked,
+  AfterViewInit,
   Component,
   ElementRef,
   Inject,
@@ -18,7 +18,7 @@ import { IImgixParams } from './types';
   selector: '[ixImg][path]',
   template: ``,
 })
-export class IxImgComponent implements AfterViewChecked {
+export class IxImgComponent implements AfterViewInit {
   private readonly client: ImgixClient;
 
   @Input('path') path: string;
@@ -70,7 +70,7 @@ export class IxImgComponent implements AfterViewChecked {
     this.client = createImgixClient(this.config);
   }
 
-  ngAfterViewChecked() {
+  ngAfterViewInit() {
     this.setSrcAndSrcsetAttributes();
     this.setOtherAttributes();
   }


### PR DESCRIPTION
Currently, the directive's attributes are set during the `afterViewChecked` lifecycle hook. This can result in situations (such as adding an `onLoad` handler) where the directive can infinitely re-render. This commit changes the lifecycle hook where attributes are set to `afterViewInit` instead.

Outstanding questions:
1. Perhaps there is a specific reason why `afterViewChecked` was originally used but to my understanding this hook shouldn't apply to ix-img since it does not have child components. However, this might not be the case for ix-source and/or ix-picture. Please let me know if there's something I missed about this approach that won't work.
2. I'm a bit stumped on how to test this fix within this project. I am able to test it but linking it to a separate project, but is this something I should be able to do in imgix-angular-example easily?

Resource: https://angular.io/guide/lifecycle-hooks#responding-to-view-changes

Fixes #231 and possibly fixes #147 