### PR TITLE
ci: update `yarn` version used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 dist: trusty
 
 language: node_js
-node_js:
-  - lts/*
-  - stable
 
 addons:
   chrome: stable
@@ -20,6 +17,12 @@ before_install:
 
 install:
   - yarn
+
+jobs:
+  include:
+  - node: lts/*
+  - node: stable
+    env: NODE_OPTIONS=--openssl-legacy-provider
 
 script:
   - yarn run test-headless

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ cache:
     - ./node_modules
 
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s
-  - export PATH=$HOME/.yarn/bin:$PATH
+  - npm install -g yarn
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 
 install:


### PR DESCRIPTION
Looking into why this project's [CI is failing](https://github.com/imgix/angular/commit/523c11fce79a13ae5aacf60d70a3184b69dbae33), I noticed that Travis is not actually downloading/installing the latest version of yarn:

```
$ curl -o- -L https://yarnpkg.com/install.sh | bash -s

curl: (60) SSL certificate problem: certificate has expired

More details here: http://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"

 of Certificate Authority (CA) public keys (CA certs). If the default

 bundle file isn't adequate, you can specify an alternate file

 using the --cacert option.

If this HTTPS server uses a certificate signed by a CA represented in

 the bundle, the certificate verification probably failed due to a

 problem with the certificate (it might be expired, or the name might

 not match the domain name in the URL).

If you'd like to turn off curl's verification of the certificate, use

 the -k (or --insecure) option.
```

This went mostly unnoticed until recently when a dependency upgrade did not agree with Travis' default yarn version. This PR changes the script to install yarn globally which should be more robust.