### PR TITLE
ci: use openssl legacy provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 dist: trusty
 
 language: node_js
-node_js:
-  - lts/*
-  - stable
 
 addons:
   chrome: stable
@@ -20,6 +17,12 @@ before_install:
 
 install:
   - yarn
+
+jobs:
+  include:
+  - node: lts/*
+  - node: stable
+    env: NODE_OPTIONS=--openssl-legacy-provider
 
 script:
   - yarn run test-headless


### PR DESCRIPTION
On node/stable builds, the following error occurs:
```
[karma-server]: UnhandledRejection: error:0308010C:digital envelope routines::unsupported
```
Currently, the most [accepted answer](https://github.com/webpack/webpack/issues/14532#issuecomment-947012063) to fix this is to use the legacy version of openssl for non-LTS node versions.