### PR TITLE
chore: add gh issue action

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -1,0 +1,19 @@
+name: Add issues to project
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/imgix/projects/4
+          github-token: ${{ secrets.GH_TOKEN }}
+          labeled: bug, needs-triage
+          label-operator: OR


### PR DESCRIPTION
Add GH action that adds an issue with a bug or needs-triage label to the issue board.