### PR TITLE
ci(deploy): add prepare and prepublishOnly step

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "test": "ng test",
+    "prepare": "ng build",
+    "prepublishOnly": "ng build",
     "test-headless": "ng test imgix-angular --no-watch --no-progress --browsers=ChromeHeadlessCI,FirefoxHeadless",
     "pretty": "prettier --write 'projects/**/*.ts'",
     "lint": "ng lint",


### PR DESCRIPTION
Adds additional scripts to ensure properly updated `dist` prior to release.

# Before

Library is not guaranteed to execute a `build` step to properly update `dist` directory prior to deployment; as a result, some libraries include the prior release in their `dist` folder.

# After

We include both a `prepare` and a `prepublishOnly` step to ensure that the library executes a build prior to deploying a release.