### PR TITLE
ci(node): support latest lts and current versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     parameters:
       version: 
-        default: "stable"
+        default: "current"
         description: Node.JS version to install
         type: string
     docker:
@@ -23,12 +23,7 @@ jobs:
             google-chrome --version
             firefox --version
           name: Check install
-      - when:
-          condition:
-            equal: [ "17.9", <<parameters.version>>]
-          steps:
-            # Prevents build error on stable node version
-            - run: echo 'export NODE_OPTIONS=--openssl-legacy-provider' >> $BASH_ENV
+      - run: echo 'export NODE_OPTIONS=--openssl-legacy-provider' >> $BASH_ENV
       - node/install-packages:
           override-ci-command: yarn install
       - run: yarn run test-headless
@@ -53,7 +48,7 @@ workflows:
           matrix:
             parameters:
               version:
-                - "17.9"
+                - "current"
                 - "lts" 
 
       - deploy:


### PR DESCRIPTION
Adds support for latest LTS and Current versions of Node, as well as unpinning Node 17.9.