### PR TITLE
ci: pin node to lts and 20.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
 
   deploy:
     docker:
-      - image: cimg/node:current
+      - image: cimg/node:20.2
     steps:
       - checkout
       - node/install-packages:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,13 @@
 version: 2.1
 
-orbs: 
+orbs:
   node: circleci/node@5.1.0
   browser-tools: circleci/browser-tools@1.4.1
 
 jobs:
   test:
     parameters:
-      version: 
+      version:
         default: "current"
         description: Node.JS version to install
         type: string
@@ -48,8 +48,8 @@ workflows:
           matrix:
             parameters:
               version:
-                - "current"
-                - "lts" 
+                - "20.2"
+                - "lts"
 
       - deploy:
           requires:


### PR DESCRIPTION
## Description

Node version 20.3 introduces a concurrency issue where the same file is getting accessed by multiple things as part of the build process. Unsure about the root cause, this commit pins currently to 20.2 to resolve the build issues for now.

A future commit should either fix the 20.3 issues.